### PR TITLE
Diff by ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,15 @@ serde               = { version = "^1.0.0", optional = true, features = ["derive
 structdiff-derive   = { path = "derive", version = "=0.5.9" }
 
 [features]
-"default"       = []
+"default"       = ["nanoserde"]
 "nanoserde"     = ["dep:nanoserde", "structdiff-derive/nanoserde"]
 "serde"         = ["dep:serde", "structdiff-derive/serde"]
 "debug_diffs"   = ["structdiff-derive/debug_diffs"]
 "generated_setters" = ["structdiff-derive/generated_setters"]
 "debug_asserts" = []
+
+[patch.crates-io]
+nanoserde           = { git = "https://github.com/not-fl3/nanoserde.git" }
 
 [dev-dependencies]
 bincode             = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structdiff"
-version = "0.5.9"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/knickish/structdiff"
@@ -9,9 +9,9 @@ keywords      = ["delta-compression", "difference"]
 categories    = ["compression"]
 
 [dependencies]
-nanoserde           = { version = "^0.1.32", optional = true }
+nanoserde           = { version = "^0.1.37", optional = true }
 serde               = { version = "^1.0.0", optional = true, features = ["derive"] }
-structdiff-derive   = { path = "derive", version = "=0.5.9" }
+structdiff-derive   = { path = "derive", version = "=0.6.0" }
 
 [features]
 "default"       = ["nanoserde"]
@@ -20,9 +20,6 @@ structdiff-derive   = { path = "derive", version = "=0.5.9" }
 "debug_diffs"   = ["structdiff-derive/debug_diffs"]
 "generated_setters" = ["structdiff-derive/generated_setters"]
 "debug_asserts" = []
-
-[patch.crates-io]
-nanoserde           = { git = "https://github.com/not-fl3/nanoserde.git" }
 
 [dev-dependencies]
 bincode             = "1.3.3"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -16,6 +16,7 @@ bincode     = { version = "1.3.3" }
 criterion = "0.5.1"
 
 [features]
+default = ["compare"]
 compare = ["dep:serde-diff", "dep:diff-struct"]
 
 [profile.bench]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 assert_unordered    = "0.3.5"
-structdiff  = { path = "..", features = ["serde"] }
+structdiff  = { path = "..", features = ["serde", "debug_diffs"] }
 nanorand    = { version = "0.7.0" } 
 diff-struct = { version = "0.5.1", optional = true} 
 serde       = { version = "^1.0.0", features = ["derive"] }

--- a/benchmarks/benches/basic.rs
+++ b/benchmarks/benches/basic.rs
@@ -36,7 +36,7 @@ fn bench_basic_generation(c: &mut Criterion) {
         .measurement_time(MEASUREMENT_TIME);
     group.bench_function(GROUP_NAME, |b| {
         b.iter(|| {
-            let diff = black_box(StructDiff::diff(&first, &second));
+            let diff = black_box(StructDiff::diff_ref(&first, &second));
             black_box(diff);
         })       
     });

--- a/benchmarks/benches/large.rs
+++ b/benchmarks/benches/large.rs
@@ -15,7 +15,7 @@ const SEED: u64 = 42;
 #[cfg(feature = "compare")]
 criterion_group!(
     benches,
-    bench_large_generation
+    bench_large_generation,
     bench_large_full,
     diff_struct_bench::bench_large,
     serde_diff_bench::bench_large
@@ -36,7 +36,7 @@ fn bench_large_generation(c: &mut Criterion) {
         .measurement_time(MEASUREMENT_TIME);
     group.bench_function(GROUP_NAME, |b| {
         b.iter(|| {
-            let diff = black_box(StructDiff::diff(&first, &second));
+            let diff = black_box(StructDiff::diff_ref(&first, &second));
             black_box(diff);
         })
     });

--- a/benchmarks/benches/large.rs
+++ b/benchmarks/benches/large.rs
@@ -15,16 +15,35 @@ const SEED: u64 = 42;
 #[cfg(feature = "compare")]
 criterion_group!(
     benches,
-    bench_large,
+    bench_large_generation
+    bench_large_full,
     diff_struct_bench::bench_large,
     serde_diff_bench::bench_large
 );
 #[cfg(not(feature = "compare"))]
-criterion_group!(benches, bench_large);
+criterion_group!(benches, bench_large_generation, bench_large_full);
 
 criterion_main!(benches);
 
-fn bench_large(c: &mut Criterion) {
+fn bench_large_generation(c: &mut Criterion) {
+    const GROUP_NAME: &str = "bench_large";
+    let mut rng = WyRand::new_seed(SEED);
+    let first = black_box(TestBench::generate_random_large(&mut rng));
+    let second = black_box(TestBench::generate_random_large(&mut rng));
+    let mut group = c.benchmark_group(GROUP_NAME);
+    group
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(MEASUREMENT_TIME);
+    group.bench_function(GROUP_NAME, |b| {
+        b.iter(|| {
+            let diff = black_box(StructDiff::diff(&first, &second));
+            black_box(diff);
+        })
+    });
+    group.finish();
+}
+
+fn bench_large_full(c: &mut Criterion) {
     const GROUP_NAME: &str = "bench_large";
     let mut rng = WyRand::new_seed(SEED);
     let mut first = black_box(TestBench::generate_random_large(&mut rng));

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -87,16 +87,19 @@ impl TestBench {
         }
     }
 
-    pub fn assert_eq(self, right: TestBench) {
-        assert_eq!(self.a, right.a);
-        assert_eq!(self.b, right.b);
-        assert_eq_unordered_sort!(self.c, right.c);
-        assert_eq_unordered_sort!(self.d, right.d);
+    #[track_caller]
+    pub fn assert_eq(self, right: TestBench, diff: &Vec<<TestBench as StructDiff>::Diff>) {
+        assert_eq!(self.a, right.a, "{:?}", diff);
+        assert_eq!(self.b, right.b, "{:?}", diff);
+        assert_eq_unordered_sort!(self.c, right.c, "{:?}", diff);
+        assert_eq_unordered_sort!(self.d, right.d, "{:?}", diff);
         assert_eq_unordered_sort!(
             self.e.iter().map(|x| x.0).collect::<Vec<_>>(),
-            right.e.iter().map(|x| x.0).collect::<Vec<_>>()
+            right.e.iter().map(|x| x.0).collect::<Vec<_>>(), 
+            "{:?}", 
+            diff
         );
-        assert_eq_unordered_sort!(self.f, right.f);
+        assert_eq_unordered_sort!(self.f, right.f, "{:?}", diff);
     }
 }
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structdiff-derive"
-version = "0.5.9"
+version = "0.6.0"
 authors = ["Makepad <info@makepad.nl>", "Fedor <not.fl3@gmail.com>", "Kirk <knickish@gmail.com"]
 edition = "2018"
 description = "derive macro library for structdiff"
@@ -10,7 +10,7 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-nanoserde           = { version = "^0.1.32", optional = true }
+nanoserde           = { version = "^0.1.37", optional = true }
 serde               = { version = "^1.0.0", optional = true, features = ["derive"] }
 
 [features]

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -24,15 +24,14 @@ pub enum CollectionStrategy {
 #[cfg(feature = "generated_setters")]
 pub fn attrs_setter(attributes: &[crate::parse::Attribute]) -> (bool, bool, Option<String>) {
     let skip = attributes
-    .iter()
-    .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "skip_setter");
+        .iter()
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "skip_setter");
     let local = attributes
-    .iter()
-    .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "setter");
+        .iter()
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "setter");
 
     let Some(name_override) = attributes.iter().find_map(|attr| {
         if attr.tokens.len() == 2 && attr.tokens[0] == "setter_name" {
-            
             Some(attr.tokens[1].clone())
         } else {
             None
@@ -47,8 +46,8 @@ pub fn attrs_setter(attributes: &[crate::parse::Attribute]) -> (bool, bool, Opti
 #[cfg(feature = "generated_setters")]
 pub fn attrs_all_setters(attributes: &[crate::parse::Attribute]) -> bool {
     attributes
-    .iter()
-    .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "setters")
+        .iter()
+        .any(|attr| attr.tokens.len() == 1 && attr.tokens[0] == "setters")
 }
 
 pub fn attrs_recurse(attributes: &[crate::parse::Attribute]) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub trait StructDiff {
 
     /// Generate a diff between two instances of a struct, for
     /// use in passing to serializer. Much more efficient for
-    /// struct with large fields where the diff will not be stored.
+    /// structs with large fields where the diff will not be stored.
     ///
     /// ```
     /// use structdiff::{Difference, StructDiff};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,63 @@ pub trait StructDiff {
     ))]
     type Diff: Clone;
 
+    /// A generated type used to represent the difference
+    /// between two instances of a struct which implements
+    /// the StructDiff trait (using references).
+    #[cfg(all(feature = "nanoserde", feature = "serde", feature = "debug_diffs"))]
+    type DiffRef<'target>: SerBin + Serialize + Clone + std::fmt::Debug + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(feature = "nanoserde", not(feature = "serde"), feature = "debug_diffs"))]
+    type DiffRef<'target>: SerBin + Clone + std::fmt::Debug + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(feature = "serde", not(feature = "nanoserde"), feature = "debug_diffs"))]
+    type DiffRef<'target>: Serialize + Clone + std::fmt::Debug + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(
+        not(feature = "serde"),
+        not(feature = "nanoserde"),
+        feature = "debug_diffs"
+    ))]
+    type DiffRef<'target>: Clone + std::fmt::Debug + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(feature = "nanoserde", feature = "serde", not(feature = "debug_diffs")))]
+    type DiffRef<'target>: SerBin + Serialize + Clone + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(
+        feature = "nanoserde",
+        not(feature = "serde"),
+        not(feature = "debug_diffs")
+    ))]
+    type DiffRef<'target>: SerBin + Clone + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(
+        feature = "serde",
+        not(feature = "nanoserde"),
+        not(feature = "debug_diffs")
+    ))]
+    type DiffRef<'target>: Serialize + Clone + Into<Self::Diff>
+    where
+        Self: 'target;
+    #[cfg(all(
+        not(feature = "serde"),
+        not(feature = "nanoserde"),
+        not(feature = "debug_diffs")
+    ))]
+    type DiffRef<'target>: Clone + Into<Self::Diff>
+    where
+        Self: 'target;
+
     /// Generate a diff between two instances of a struct.
     /// This diff may be serialized if one of the serialization
     /// features is enabled.
     ///
     /// ```
-    /// # #[cfg(not(feature = "nanoserde"))] {
     /// use structdiff::{Difference, StructDiff};
     ///
     /// #[derive(Debug, PartialEq, Clone, Difference)]
@@ -66,13 +117,39 @@ pub trait StructDiff {
     ///     field1: 3.14,
     /// };
     ///
-    /// let diffs = first.diff(&second);
+    /// let diffs: Vec<<Example as StructDiff>::Diff> = first.diff(&second);
     ///
     /// let diffed = first.apply(diffs);
     /// assert_eq!(diffed, second);
-    /// # }
     /// ```
     fn diff(&self, updated: &Self) -> Vec<Self::Diff>;
+
+    /// Generate a diff between two instances of a struct, for
+    /// use in passing to serializer. Much more efficient for
+    /// struct with large fields where the diff will not be stored.
+    ///
+    /// ```
+    /// use structdiff::{Difference, StructDiff};
+    ///
+    /// #[derive(Debug, PartialEq, Clone, Difference)]
+    /// struct Example {
+    ///     field1: f64,
+    /// }
+    ///
+    /// let first = Example {
+    ///     field1: 0.0,
+    /// };
+    ///
+    /// let second = Example {
+    ///     field1: 3.14,
+    /// };
+    ///
+    /// let diffs: Vec<<Example as StructDiff>::DiffRef<'_>> = first.diff_ref(&second);
+    ///
+    /// let diffed = first.clone().apply(diffs.into_iter().map(Into::into).collect());
+    /// assert_eq!(diffed, second);
+    /// ```
+    fn diff_ref<'target>(&'target self, updated: &'target Self) -> Vec<Self::DiffRef<'target>>;
 
     /// Apply a single-field diff to a mutable self ref
     fn apply_single(&mut self, diff: Self::Diff);

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -35,6 +35,7 @@ where
 #[allow(unused)]
 #[cfg(not(any(feature = "serde", feature = "nanoserde")))]
 #[derive(PartialEq, Difference, Clone, Debug)]
+// #[derive(PartialEq, Clone, Debug)]
 pub enum TestDeriveAllEnum<
     'a,
     'b: 'a,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20,6 +20,16 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "nanoserde")]
 use nanoserde::{DeBin, SerBin};
 
+macro_rules! nanoserde_ref_test {
+    ($first:ident, $second:ident) => {
+        #[cfg(feature = "nanoserde")]
+        assert_eq!(
+            nanoserde::SerBin::serialize_bin(&(&$first).diff(&$second)),
+            nanoserde::SerBin::serialize_bin(&(&$first).diff_ref(&$second))
+        )
+    };
+}
+
 #[test]
 /// This should match the code used in README.md
 fn test_example() {
@@ -75,9 +85,10 @@ fn test_derive() {
     };
 
     let diffs = first.diff(&second);
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
-    assert_eq!(diffed, second);
+    assert_eq!(&diffed, &second);
+    nanoserde_ref_test!(first, second);
 }
 
 #[test]
@@ -121,13 +132,15 @@ fn test_derive_with_skip() {
         assert_eq!(diffed_serde.test4, second.test4);
     }
 
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
     //check that all except the skipped are changed
     assert_eq!(diffed.test1, second.test1);
     assert_eq!(diffed.test2, second.test2);
     assert_ne!(diffed.test3skip, second.test3skip);
     assert_eq!(diffed.test4, second.test4);
+
+    nanoserde_ref_test!(first, second);
 }
 
 #[derive(Debug, PartialEq, Clone, Difference)]
@@ -177,13 +190,15 @@ fn test_generics() {
         assert_eq!(&diffed_serde, &second);
     }
 
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
     //check that all except the skipped are changed
     assert_eq!(diffed.test1, second.test1);
     assert_eq!(diffed.test2, second.test2);
     assert_eq!(diffed.test3, second.test3);
     assert_eq!(diffed.test4, second.test4);
+
+    nanoserde_ref_test!(first, second)
 }
 
 #[derive(Debug, PartialEq, Clone, Difference)]
@@ -242,7 +257,7 @@ fn test_generics_skip() {
         assert_eq!(diffed_serde.test5, second.test5);
     }
 
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
     //check that all except the skipped are changed
     assert_eq!(diffed.test1, second.test1);
@@ -250,6 +265,8 @@ fn test_generics_skip() {
     assert_eq!(diffed.test3, second.test3);
     assert_ne!(diffed.test4, second.test4);
     assert_eq!(diffed.test5, second.test5);
+
+    nanoserde_ref_test!(first, second);
 }
 
 #[test]
@@ -260,7 +277,8 @@ fn test_enums() {
         leader = TestEnum::next();
         let diff = follower.diff(&leader);
         follower.apply_mut(diff);
-        assert_eq!(leader, follower)
+        assert_eq!(&leader, &follower);
+        nanoserde_ref_test!(leader, follower);
     }
 }
 
@@ -287,9 +305,10 @@ mod derive_inner {
         };
 
         let diffs = first.diff(&second);
-        let diffed = first.apply(diffs);
+        let diffed = first.clone().apply(diffs);
 
         assert_eq!(diffed, second);
+        nanoserde_ref_test!(first, second);
     }
 }
 
@@ -377,9 +396,10 @@ fn test_recurse() {
         assert_eq!(&diffed_serde, &second);
     }
 
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
     assert_eq!(diffed, second);
+    nanoserde_ref_test!(first, second);
 }
 
 #[test]
@@ -431,12 +451,14 @@ fn test_collection_strategies() {
         assert_eq_unordered!(&diffed_nserde.test3, &second.test3);
     }
 
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
     use assert_unordered::assert_eq_unordered;
-    assert_eq_unordered!(diffed.test1, second.test1);
-    assert_eq_unordered!(diffed.test2, second.test2);
-    assert_eq_unordered!(diffed.test3, second.test3);
+    assert_eq_unordered!(&diffed.test1, &second.test1);
+    assert_eq_unordered!(&diffed.test2, &second.test2);
+    assert_eq_unordered!(&diffed.test3, &second.test3);
+
+    nanoserde_ref_test!(first, second);
 }
 
 #[test]
@@ -483,10 +505,12 @@ fn test_key_value() {
         assert_eq_unordered!(&diffed_serde.test1, &second.test1);
     }
 
-    let diffed = first.apply(diffs);
+    let diffed = first.clone().apply(diffs);
 
     use assert_unordered::assert_eq_unordered;
-    assert_eq_unordered!(diffed.test1, second.test1);
+    assert_eq_unordered!(&diffed.test1, &second.test1);
+
+    nanoserde_ref_test!(first, second);
 }
 
 #[cfg(feature = "generated_setters")]


### PR DESCRIPTION
Adds the option to generate a diff by ref rather than cloning the contents. This substantially reduces the amount of work done when diffs are serialized and then discarded (for application on the other side of a network connection) rather than applied locally