### PR TITLE
second pass on performance of collections diffs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories    = ["compression"]
 
 [dependencies]
 nanoserde           = { version = "^0.1.37", optional = true }
+rustc-hash          = { version = "1.1.0", optional = true }
 serde               = { version = "^1.0.0", optional = true, features = ["derive"] }
 structdiff-derive   = { path = "derive", version = "=0.6.1" }
 
@@ -19,6 +20,7 @@ structdiff-derive   = { path = "derive", version = "=0.6.1" }
 "serde"         = ["dep:serde", "structdiff-derive/serde"]
 "debug_diffs"   = ["structdiff-derive/debug_diffs"]
 "generated_setters" = ["structdiff-derive/generated_setters"]
+"rustc_hash"    = ["dep:rustc-hash"]
 "debug_asserts" = []
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For more examples take a look at [integration tests](/tests)
 - [`nanoserde`, `serde`] - Serialization of `Difference` derived associated types. Allows diffs to easily be sent over network.
 - `debug_diffs` - Derive `Debug` on the generated diff type
 - `generated_setters` - Enable generation of setters for struct fields. These setters automatically return a diff if a field's value is changed by the assignment.
+- `rustc_hash` - Use the (non-cryptographic) hash implementation from the `rustc-hash` crate instead of the default hasher. Much faster diff generation for collections at the cost of a dependency.
 
 ### Development status 
 This is being used actively for my own projects, although it's mostly working now. PRs will be accepted for either more tests or functionality.

--- a/benchmarks/benches/basic.rs
+++ b/benchmarks/benches/basic.rs
@@ -26,7 +26,7 @@ criterion_group!(benches, bench_basic_generation, bench_basic_full);
 criterion_main!(benches);
 
 fn bench_basic_generation(c: &mut Criterion) {
-    const GROUP_NAME: &str = "bench_basic";
+    const GROUP_NAME: &str = "bench_basic_ref_gen";
     let mut rng = WyRand::new_seed(SEED);
     let first = black_box(TestBench::generate_random(&mut rng));
     let second = black_box(TestBench::generate_random(&mut rng));
@@ -44,7 +44,7 @@ fn bench_basic_generation(c: &mut Criterion) {
 }
 
 fn bench_basic_full(c: &mut Criterion) {
-    const GROUP_NAME: &str = "bench_basic";
+    const GROUP_NAME: &str = "bench_basic_owned";
     let mut rng = WyRand::new_seed(SEED);
     let mut first = black_box(TestBench::generate_random(&mut rng));
 

--- a/benchmarks/benches/basic.rs
+++ b/benchmarks/benches/basic.rs
@@ -38,7 +38,7 @@ fn bench_basic_generation(c: &mut Criterion) {
         b.iter(|| {
             let diff = black_box(StructDiff::diff_ref(&first, &second));
             black_box(diff);
-        })       
+        })
     });
     group.finish();
 }
@@ -47,7 +47,7 @@ fn bench_basic_full(c: &mut Criterion) {
     const GROUP_NAME: &str = "bench_basic";
     let mut rng = WyRand::new_seed(SEED);
     let mut first = black_box(TestBench::generate_random(&mut rng));
-    
+
     let second = black_box(TestBench::generate_random(&mut rng));
     let mut diff: Vec<<TestBench as StructDiff>::Diff> = Vec::new();
     let mut group = c.benchmark_group(GROUP_NAME);
@@ -58,7 +58,7 @@ fn bench_basic_full(c: &mut Criterion) {
         b.iter(|| {
             diff = black_box(StructDiff::diff(&first, &second));
             black_box(first.apply_mut(diff.clone()));
-        })       
+        })
     });
     group.finish();
     first.assert_eq(second, &diff);

--- a/benchmarks/benches/large.rs
+++ b/benchmarks/benches/large.rs
@@ -26,7 +26,7 @@ criterion_group!(benches, bench_large_generation, bench_large_full);
 criterion_main!(benches);
 
 fn bench_large_generation(c: &mut Criterion) {
-    const GROUP_NAME: &str = "bench_large";
+    const GROUP_NAME: &str = "bench_large_ref_gen";
     let mut rng = WyRand::new_seed(SEED);
     let first = black_box(TestBench::generate_random_large(&mut rng));
     let second = black_box(TestBench::generate_random_large(&mut rng));
@@ -44,7 +44,7 @@ fn bench_large_generation(c: &mut Criterion) {
 }
 
 fn bench_large_full(c: &mut Criterion) {
-    const GROUP_NAME: &str = "bench_large";
+    const GROUP_NAME: &str = "bench_large_owned";
     let mut rng = WyRand::new_seed(SEED);
     let mut first = black_box(TestBench::generate_random_large(&mut rng));
     let second = black_box(TestBench::generate_random_large(&mut rng));

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -95,8 +95,8 @@ impl TestBench {
         assert_eq_unordered_sort!(self.d, right.d, "{:?}", diff);
         assert_eq_unordered_sort!(
             self.e.iter().map(|x| x.0).collect::<Vec<_>>(),
-            right.e.iter().map(|x| x.0).collect::<Vec<_>>(), 
-            "{:?}", 
+            right.e.iter().map(|x| x.0).collect::<Vec<_>>(),
+            "{:?}",
             diff
         );
         assert_eq_unordered_sort!(self.f, right.f, "{:?}", diff);

--- a/src/collections/unordered_map_like.rs
+++ b/src/collections/unordered_map_like.rs
@@ -111,7 +111,8 @@ fn collect_into_key_eq_map<
 >(
     list: B,
 ) -> HashMap<&'a K, (&'a V, usize)> {
-    let mut map: HashMap<&K, (&V, usize)> = HashMap::new();
+    let mut map: HashMap<&K, (&V, usize)> =
+        HashMap::with_capacity(list.size_hint().1.unwrap_or_default());
     for (key, value) in list {
         match map.get_mut(&key) {
             Some((_, count)) => *count += 1,
@@ -225,7 +226,8 @@ pub fn unordered_hashcmp<
         )));
     }
 
-    let mut ret: Vec<UnorderedMapLikeChange<&'a K, &'a V>> = vec![];
+    let mut ret: Vec<UnorderedMapLikeChange<&'a K, &'a V>> =
+        Vec::with_capacity((previous.len() + current.len()) >> 1);
 
     for (&k, &(v, current_count)) in current.iter() {
         match previous.remove(&k) {
@@ -282,6 +284,8 @@ pub fn unordered_hashcmp<
             Operation::Remove,
         ))
     }
+
+    ret.shrink_to_fit();
 
     match ret.is_empty() {
         true => None,

--- a/src/collections/unordered_map_like_recursive.rs
+++ b/src/collections/unordered_map_like_recursive.rs
@@ -110,7 +110,7 @@ fn collect_into_key_eq_map<
 >(
     list: B,
 ) -> HashMap<&'a K, &'a V> {
-    let mut map: HashMap<&K, &V> = HashMap::new();
+    let mut map: HashMap<&K, &V> = HashMap::with_capacity(list.size_hint().1.unwrap_or_default());
     for (key, value) in list {
         map.insert(key, value);
     }
@@ -170,7 +170,8 @@ pub fn unordered_hashcmp<
             ));
         }
 
-        let mut ret: Vec<UnorderedMapLikeRecursiveChangeRef<'a, K, V>> = vec![];
+        let mut ret: Vec<UnorderedMapLikeRecursiveChangeRef<'a, K, V>> =
+            Vec::with_capacity((previous.len() + current.len()) >> 1);
 
         for prev_entry in previous.into_iter() {
             if current.remove_entry(prev_entry.0).is_none() {
@@ -188,6 +189,8 @@ pub fn unordered_hashcmp<
             ))
         }
 
+        ret.shrink_to_fit();
+
         match ret.is_empty() {
             true => None,
             false => Some(UnorderedMapLikeRecursiveDiffRef(
@@ -203,7 +206,8 @@ pub fn unordered_hashcmp<
             ));
         }
 
-        let mut ret: Vec<UnorderedMapLikeRecursiveChangeRef<'a, K, V>> = vec![];
+        let mut ret: Vec<UnorderedMapLikeRecursiveChangeRef<'a, K, V>> =
+            Vec::with_capacity((previous.len() + current.len()) >> 1);
 
         for prev_entry in previous.into_iter() {
             match current.remove_entry(prev_entry.0) {
@@ -228,6 +232,8 @@ pub fn unordered_hashcmp<
             ))
         }
 
+        ret.shrink_to_fit();
+
         match ret.is_empty() {
             true => None,
             false => Some(UnorderedMapLikeRecursiveDiffRef(
@@ -245,7 +251,7 @@ pub fn apply_unordered_hashdiffs<
 >(
     list: B,
     diffs: UnorderedMapLikeRecursiveDiffOwned<K, V>,
-) -> Box<dyn Iterator<Item = (K, V)>> {
+) -> Box<dyn ExactSizeIterator<Item = (K, V)>> {
     let diffs = match diffs {
         UnorderedMapLikeRecursiveDiffOwned(
             UnorderedMapLikeRecursiveDiffInternalOwned::Replace(replacement),


### PR DESCRIPTION
- use size hints internally for collection diffing
- use `rustc_hash` instead of `std` for collection diffing (optional, behind `rustc_hash` feature)