### PR TITLE
add #[difference(export)] attribute to allow pub diff types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/knickish/structdiff"
 description = """zero-dependency crate for generating and applying partial diffs between struct instances"""
 keywords      = ["delta-compression", "difference"]
 categories    = ["compression"]
+rust-version = "1.82.0"
 
 [dependencies]
 nanoserde           = { version = "^0.1.37", optional = true }

--- a/README.md
+++ b/README.md
@@ -48,19 +48,22 @@ assert_ne!(diffed, second);
 For more examples take a look at [integration tests](/tests)
 
 ## Derive macro attributes
-- `#[difference(skip)]` - Do not consider this field when creating a diff
-- `#[difference(recurse)]` - Generate a StructDiff for this field when creating a diff
-- `#[difference(collection_strategy = {})]`
-    - `"ordered_array_like"` - Generates a minimal changeset for ordered, array-like collections of items which implement `PartialEq`. (uses levenshtein difference)
-    - `"unordered_array_like"` - Generates a minimal changeset for unordered, array-like collections of items which implement `Hash + Eq`.
-    - `"unordered_map_like"` - Generates a minimal changeset for unordered, map-like collections for which the key implements `Hash + Eq`.
-- `#[difference(map_equality = {})]` - Used with `unordered_map_like`
-    - `"key_only"` - only replace a key-value pair for which the key has changed
-    - `"key_and_value"` - replace a key-value pair if either the key or value has changed
-- `#[difference(setters)]` - Generate setters for all fields in the struct (used on struct)
-    - Example: for the `field1` of the `Example` struct used above, a function with the signature `set_field1_with_diff(&mut self, value: Option<usize>) -> Option<<Self as StructDiff>::Diff>` will be generated. Useful when a single field will be changed in a struct with many fields, as it saves the comparison of all other fields. 
-- `#[difference(setter)]` - Generate setters for this struct field (used on field)
-- `#[difference(setter_name = {})]` - Use this name instead of the default value when generating a setter for this field (used on field)
+- Field level
+    - `#[difference(skip)]` - Do not consider this field when creating a diff
+    - `#[difference(recurse)]` - Generate a StructDiff for this field when creating a diff
+    - `#[difference(collection_strategy = {})]`
+        - `"ordered_array_like"` - Generates a minimal changeset for ordered, array-like collections of items which implement `PartialEq`. (uses levenshtein difference)
+        - `"unordered_array_like"` - Generates a minimal changeset for unordered, array-like collections of items which implement `Hash + Eq`.
+        - `"unordered_map_like"` - Generates a minimal changeset for unordered, map-like collections for which the key implements `Hash + Eq`.
+    - `#[difference(map_equality = {})]` - Used with `unordered_map_like`
+        - `"key_only"` - only replace a key-value pair for which the key has changed
+        - `"key_and_value"` - replace a key-value pair if either the key or value has changed
+    - `#[difference(setter)]` - Generate setters for this struct field
+    - `#[difference(setter_name = {})]` - Use this name instead of the default value when generating a setter for this field (used on field)
+- Struct Level
+    - `#[difference(setters)]` - Generate setters for all fields in the struct 
+        - Example: for the `field1` of the `Example` struct used above, a function with the signature `set_field1_with_diff(&mut self, value: Option<usize>) -> Option<<Self as StructDiff>::Diff>` will be generated. Useful when a single field will be changed in a struct with many fields, as it saves the comparison of all other fields. 
+    - `#[difference(expose)]`/`#[difference(expose = "MyDiffTypeName")]` - expose the generated difference type (optionally, with the specified name)
 
 ## Optional features
 - [`nanoserde`, `serde`] - Serialization of `Difference` derived associated types. Allows diffs to easily be sent over network.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -16,11 +16,10 @@ mod parse;
 pub fn derive_struct_diff(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse::parse_data(input);
 
-    // ok we have an ident, hopefully it's a struct
     let ts = match &input {
         parse::Data::Struct(struct_) if struct_.named => derive_struct_diff_struct(struct_),
         parse::Data::Enum(enum_) => derive_struct_diff_enum(enum_),
-        _ => unimplemented!("Only structs are supported"),
+        _ => unimplemented!("Only structs and enums are supported"),
     };
 
     ts

--- a/derive/src/shared.rs
+++ b/derive/src/shared.rs
@@ -100,3 +100,11 @@ pub fn attrs_map_strategy(attributes: &[crate::parse::Attribute]) -> Option<MapS
         }
     })
 }
+
+pub fn attrs_expose(attributes: &[crate::parse::Attribute]) -> Option<Option<String>> {
+    attributes.iter().find_map(|attr| match attr.tokens.len() {
+        1 if attr.tokens[0].starts_with("expose") => Some(None),
+        2.. if attr.tokens[0] == "expose" => Some(Some((&attr.tokens[1]).to_string())),
+        _ => return None,
+    })
+}

--- a/src/collections/ordered_array_like.rs
+++ b/src/collections/ordered_array_like.rs
@@ -237,6 +237,7 @@ fn create_last_change_row<'src, 'target: 'src, T: Clone + PartialEq + 'target>(
     let mut target_forward = target_start..target_end;
     let mut target_rev = (target_end..target_start).rev();
 
+    #[allow(clippy::type_complexity)]
     let (target_range, source_range): (
         &mut dyn Iterator<Item = usize>,
         Box<dyn Fn() -> Box<dyn Iterator<Item = usize>>>,
@@ -750,9 +751,7 @@ mod test {
                 return;
             };
 
-            let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                .into_iter()
-                .collect::<String>();
+            let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
             assert_eq!(s1, changed)
         }
     }
@@ -765,18 +764,14 @@ mod test {
         let s1_vec = s1.chars().collect::<Vec<_>>();
         let s2_vec = s2.chars().collect::<Vec<_>>();
 
-        for diff_type in [
-            // levenshtein,
-            hirschberg,
-        ] {
+        {
+            let diff_type = hirschberg;
             let Some(changes) = diff_type(&s1_vec, &s2_vec) else {
                 assert_eq!(&s1_vec, &s2_vec);
                 return;
             };
 
-            let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                .into_iter()
-                .collect::<String>();
+            let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
             assert_eq!(s1, changed)
         }
     }
@@ -786,10 +781,8 @@ mod test {
         let s1: Vec<char> = "abc".chars().collect();
         let s2: Vec<char> = "".chars().collect();
 
-        for diff_type in [
-            // levenshtein,
-            hirschberg,
-        ] {
+        {
+            let diff_type = hirschberg;
             let Some(changes) = diff_type(&s1, &s2) else {
                 assert_eq!(s1, s2);
                 return;
@@ -870,9 +863,7 @@ mod test {
                     continue;
                 };
 
-                let changed = apply(changes, s2_vec.clone())
-                    .into_iter()
-                    .collect::<Vec<char>>();
+                let changed = apply(changes, s2_vec.clone()).collect::<Vec<char>>();
                 assert_eq!(&s1_vec, &changed);
             }
         }
@@ -1005,9 +996,7 @@ mod test {
                 return;
             };
 
-            let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                .into_iter()
-                .collect::<String>();
+            let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
             assert_eq!(s1, changed)
         }
 
@@ -1024,9 +1013,7 @@ mod test {
                 return;
             };
 
-            let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                .into_iter()
-                .collect::<String>();
+            let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
             assert_eq!(s1, changed)
         }
 
@@ -1043,9 +1030,7 @@ mod test {
                     return;
                 };
 
-                let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                    .into_iter()
-                    .collect::<String>();
+                let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
                 assert_eq!(s1, changed)
             }
         }
@@ -1063,9 +1048,7 @@ mod test {
                     return;
                 };
 
-                let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                    .into_iter()
-                    .collect::<String>();
+                let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
                 assert_eq!(s1, changed)
             }
         }
@@ -1083,9 +1066,7 @@ mod test {
                     return;
                 };
 
-                let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                    .into_iter()
-                    .collect::<String>();
+                let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
                 assert_eq!(s1, changed)
             }
         }
@@ -1103,9 +1084,7 @@ mod test {
                     return;
                 };
 
-                let changed = apply(changes, s2.chars().collect::<Vec<_>>())
-                    .into_iter()
-                    .collect::<String>();
+                let changed = apply(changes, s2.chars().collect::<Vec<_>>()).collect::<String>();
                 assert_eq!(s1, changed)
             }
         }

--- a/src/collections/unordered_array_like.rs
+++ b/src/collections/unordered_array_like.rs
@@ -166,7 +166,7 @@ pub fn unordered_hashcmp<
             UnorderedArrayLikeDiffInternal::Replace(
                 current
                     .into_iter()
-                    .flat_map(|(k, v)| std::iter::repeat(k).take(v))
+                    .flat_map(|(k, v)| std::iter::repeat_n(k, v))
                     .collect(),
             ),
         ));
@@ -333,7 +333,7 @@ where
     Box::new(
         list_hash
             .into_iter()
-            .flat_map(|(k, v)| std::iter::repeat(k).take(v)),
+            .flat_map(|(k, v)| std::iter::repeat_n(k, v)),
     )
 }
 

--- a/src/collections/unordered_map_like.rs
+++ b/src/collections/unordered_map_like.rs
@@ -167,7 +167,7 @@ pub fn unordered_hashcmp<
         return Some(UnorderedMapLikeDiff(UnorderedMapLikeDiffInternal::Replace(
             current
                 .into_iter()
-                .flat_map(|(k, (v, count))| std::iter::repeat((k, v)).take(count))
+                .flat_map(|(k, (v, count))| std::iter::repeat_n((k, v), count))
                 .collect(),
         )));
     }
@@ -319,7 +319,7 @@ pub fn apply_unordered_hashdiffs<
     Box::new(
         list_hash
             .into_iter()
-            .flat_map(|(k, (v, count))| std::iter::repeat((k.clone(), v.clone())).take(count))
+            .flat_map(|(k, (v, count))| std::iter::repeat_n((k.clone(), v.clone()), count))
             .collect::<Vec<_>>()
             .into_iter(),
     )

--- a/tests/derives.rs
+++ b/tests/derives.rs
@@ -1,4 +1,4 @@
-#![allow(unused_imports)]
+#![allow(unused_imports, clippy::type_complexity)]
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},

--- a/tests/expose.rs
+++ b/tests/expose.rs
@@ -1,0 +1,72 @@
+#![allow(unused_imports)]
+
+use assert_unordered::{assert_eq_unordered, assert_eq_unordered_sort};
+
+use std::f64::consts::PI;
+use std::hash::Hash;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList},
+    fmt::Debug,
+    num::Wrapping,
+};
+use structdiff::{Difference, StructDiff};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "nanoserde")]
+use nanoserde::{DeBin, SerBin};
+
+#[test]
+fn test_expose() {
+    #[derive(Debug, PartialEq, Clone, Difference)]
+    #[difference(expose)]
+    struct Example {
+        field1: f64,
+    }
+
+    let first = Example { field1: 0.0 };
+
+    let second = Example { field1: PI };
+
+    for diff in first.diff(&second) {
+        match diff {
+            ExampleStructDiffEnum::field1(v) => {
+                dbg!(&v);
+            }
+        }
+    }
+
+    for diff in first.diff_ref(&second) {
+        match diff {
+            ExampleStructDiffEnumRef::field1(v) => {
+                dbg!(&v);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_expose_rename() {
+    #[derive(Debug, PartialEq, Clone, Difference)]
+    #[difference(expose = "Cheese")]
+    struct Example {
+        field1: f64,
+    }
+
+    let first = Example { field1: 0.0 };
+
+    let second = Example { field1: PI };
+
+    for diff in first.diff(&second) {
+        match diff {
+            Cheese::field1(_v) => {}
+        }
+    }
+
+    for diff in first.diff_ref(&second) {
+        match diff {
+            CheeseRef::field1(_v) => {}
+        }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,10 +2,12 @@
 
 mod derives;
 mod enums;
+mod expose;
 mod types;
 use assert_unordered::{assert_eq_unordered, assert_eq_unordered_sort};
 pub use types::{RandValue, Test, TestEnum, TestSkip};
 
+use std::f32::consts::PI;
 use std::hash::Hash;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList},
@@ -49,7 +51,7 @@ fn test_example() {
     };
 
     let second = Example {
-        field1: 3.14,
+        field1: PI as f64,
         field2: vec![1],
         field3: vec![2, 3, 4].into_iter().collect(),
     };
@@ -80,7 +82,7 @@ fn test_derive() {
         test1: first.test1,
         test2: String::from("Hello Diff"),
         test3: vec![1],
-        test4: 3.14,
+        test4: PI,
         test5: Some(12),
     };
 
@@ -104,7 +106,7 @@ fn test_derive_with_skip() {
         test1: first.test1,
         test2: String::from("Hello Diff"),
         test3skip: vec![1],
-        test4: 3.14,
+        test4: PI,
     };
 
     let diffs = first.diff(&second);
@@ -283,6 +285,8 @@ fn test_enums() {
 }
 
 mod derive_inner {
+    use std::f32::consts::PI;
+
     use super::{StructDiff, Test};
     //tests that the associated type does not need to be exported manually
 
@@ -300,7 +304,7 @@ mod derive_inner {
             test1: first.test1,
             test2: String::from("Hello Diff"),
             test3: vec![1],
-            test4: 3.14,
+            test4: PI,
             test5: Some(13),
         };
 
@@ -354,7 +358,7 @@ fn test_recurse() {
             test1: 2,
             test2: String::new(),
             test3: Vec::new(),
-            test4: 3.14,
+            test4: PI,
             test5: None,
         },
         test3: Some(Test::default()),

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -145,11 +145,7 @@ mod generators {
 
     pub(super) fn rand_bool(rng: &mut WyRand) -> bool {
         let base = rng.generate::<u8>() as usize;
-        if base % 2 == 0 {
-            true
-        } else {
-            false
-        }
+        base % 2 == 0
     }
 
     pub(super) fn rand_string(rng: &mut WyRand) -> String {


### PR DESCRIPTION
Wasn't super happy with the solution to #34. This PR adds an `expose` attribute which defines the derive-created `Diff` and `DiffRef` types outside of the `const _: () {}` block normally used to prevent namespace pollution. Either   `[difference(expose)]` or `[difference(expose = "MyDiffName")]` can be used to expose the type