### PR TITLE
Fix enum attribute parsing - allows exposing enum diff stucts

### DIFF
--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -1595,7 +1595,8 @@ pub fn parse_data(input: TokenStream) -> Data {
             res = Data::Struct(struct_);
         }
         "enum" => {
-            let enum_ = next_enum(&mut source);
+            let mut enum_ = next_enum(&mut source);
+            enum_.attributes = attributes;
             res = Data::Enum(enum_);
         }
         "union" => unimplemented!("Unions are not supported"),

--- a/tests/expose.rs
+++ b/tests/expose.rs
@@ -70,3 +70,22 @@ fn test_expose_rename() {
         }
     }
 }
+
+#[test]
+fn test_expose_enum() {
+    #[derive(Debug, Clone, PartialEq, Difference)]
+    #[difference(expose)]
+    pub enum Test {
+        A,
+        B(u32),
+    }
+
+    let first = Test::A;
+    let second = Test::B(1);
+
+    for diff in first.diff(&second) {
+        match diff {
+            TestStructDiffEnum::Replace(_) => {}
+        }
+    }
+}


### PR DESCRIPTION
The #[difference(expose)] attribute wasn't working for enums.  It turns out that enum attributes weren't getting stored. This change fixes that.